### PR TITLE
Test coverage for the combinators!

### DIFF
--- a/src/channels/watch.rs
+++ b/src/channels/watch.rs
@@ -17,8 +17,9 @@ use std::{
 use static_assertions::{assert_impl_all, assert_not_impl_all};
 
 use crate::{
+    sink::{PollSend, Sink},
+    stream::{PollRecv, Stream},
     sync::{shared, ReceiverShared, SenderShared},
-    PollRecv, PollSend, Sink, Stream,
 };
 
 /// Constructs a new watch channel pair, filled with T::default()
@@ -52,7 +53,7 @@ impl<T> Sink for Sender<T> {
         self: std::pin::Pin<&mut Self>,
         _cx: &mut crate::Context<'_>,
         value: Self::Item,
-    ) -> crate::PollSend<Self::Item> {
+    ) -> PollSend<Self::Item> {
         if self.shared.is_closed() {
             return PollSend::Rejected(value);
         }
@@ -83,7 +84,7 @@ where
     fn poll_recv(
         self: std::pin::Pin<&mut Self>,
         cx: &mut crate::Context<'_>,
-    ) -> crate::PollRecv<Self::Item> {
+    ) -> PollRecv<Self::Item> {
         match self.try_recv_internal() {
             TryRecv::Pending => {
                 self.shared.subscribe_send(cx);
@@ -187,8 +188,11 @@ mod tests {
     use std::{pin::Pin, task::Context};
 
     use super::channel;
-    use crate::test::{noop_context, panic_context};
-    use crate::{PollRecv, PollSend, Sink, Stream};
+    use crate::{
+        sink::{PollSend, Sink},
+        stream::{PollRecv, Stream},
+        test::{noop_context, panic_context},
+    };
     use futures_test::task::new_count_waker;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
@@ -389,8 +393,9 @@ mod tokio_tests {
     use tokio::{spawn, time::timeout};
 
     use crate::{
+        sink::Sink,
+        stream::Stream,
         test::{Channel, Channels, Message, CHANNEL_TEST_RECEIVERS, TEST_TIMEOUT},
-        Sink, Stream,
     };
 
     #[tokio::test]
@@ -455,8 +460,9 @@ mod async_std_tests {
     use async_std::{future::timeout, task::spawn};
 
     use crate::{
+        sink::Sink,
+        stream::Stream,
         test::{Channel, Channels, Message, CHANNEL_TEST_RECEIVERS, TEST_TIMEOUT},
-        Sink, Stream,
     };
 
     #[async_std::test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -33,6 +33,7 @@ impl<'a> Context<'a> {
         Context { waker: Some(waker) }
     }
 
+    /// Create an empty context with no waker.
     pub fn empty() -> Self {
         Self { waker: None }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ mod channels;
 #[macro_use]
 mod logging;
 mod context;
-mod sink;
-mod stream;
+pub mod sink;
+pub mod stream;
 mod sync;
 
 pub use channels::barrier;
@@ -29,9 +29,6 @@ pub use channels::oneshot;
 pub use channels::watch;
 
 pub use context::Context;
-
-pub use sink::*;
-pub use stream::*;
 
 #[cfg(test)]
 mod test;

--- a/src/sink/filter.rs
+++ b/src/sink/filter.rs
@@ -2,17 +2,17 @@ use std::pin::Pin;
 
 use crate::Context;
 
-use crate::{PollSend, Sink};
+use crate::sink::{PollSend, Sink};
 use pin_project::pin_project;
 
 #[pin_project]
-pub struct SinkFilter<Filter, Into> {
+pub struct FilterSink<Filter, Into> {
     filter: Filter,
     #[pin]
     into: Into,
 }
 
-impl<Filter, Into> SinkFilter<Filter, Into>
+impl<Filter, Into> FilterSink<Filter, Into>
 where
     Into: Sink,
     Filter: FnMut(&Into::Item) -> bool,
@@ -22,7 +22,7 @@ where
     }
 }
 
-impl<Filter, Into> Sink for SinkFilter<Filter, Into>
+impl<Filter, Into> Sink for FilterSink<Filter, Into>
 where
     Into: Sink,
     Filter: FnMut(&Into::Item) -> bool,
@@ -33,12 +33,90 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         value: Self::Item,
-    ) -> crate::PollSend<Self::Item> {
+    ) -> PollSend<Self::Item> {
         let this = self.project();
         if !(this.filter)(&value) {
             return PollSend::Ready;
         }
 
         this.into.poll_send(cx, value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+
+    use crate::test::sink::*;
+    use crate::{
+        sink::{PollSend, Sink},
+        Context,
+    };
+
+    use super::FilterSink;
+
+    #[test]
+    fn simple() {
+        let mut test_sink = test_sink(vec![PollSend::Ready, PollSend::Ready]);
+        let mut filter = FilterSink::new(|i| i % 2 == 0, &mut test_sink);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(
+            PollSend::Ready,
+            Pin::new(&mut filter).poll_send(&mut cx, 1usize)
+        );
+        assert_eq!(
+            PollSend::Ready,
+            Pin::new(&mut filter).poll_send(&mut cx, 2usize)
+        );
+        assert_eq!(
+            PollSend::Ready,
+            Pin::new(&mut filter).poll_send(&mut cx, 3usize)
+        );
+        assert_eq!(
+            PollSend::Ready,
+            Pin::new(&mut filter).poll_send(&mut cx, 4usize)
+        );
+
+        drop(filter);
+
+        assert_eq!(&[2, 4], test_sink.values());
+    }
+
+    #[test]
+    fn forward_pending() {
+        let source = pending::<usize>();
+        let mut find = FilterSink::new(|_| true, source);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(
+            PollSend::Pending(1),
+            Pin::new(&mut find).poll_send(&mut cx, 1)
+        );
+    }
+
+    #[test]
+    fn forward_closed() {
+        let source = rejected::<usize>();
+        let mut find = FilterSink::new(|_| true, source);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(
+            PollSend::Rejected(1),
+            Pin::new(&mut find).poll_send(&mut cx, 1)
+        );
+    }
+
+    #[test]
+    fn ignored_ready() {
+        let source = rejected::<usize>();
+        let mut find = FilterSink::new(|_| false, source);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(PollSend::Ready, Pin::new(&mut find).poll_send(&mut cx, 1));
     }
 }

--- a/src/sink/sink_log.rs
+++ b/src/sink/sink_log.rs
@@ -1,4 +1,4 @@
-use crate::{PollSend, Sink};
+use crate::sink::{PollSend, Sink};
 use log::log_enabled;
 use pin_project::pin_project;
 use std::{fmt::Debug, pin::Pin};
@@ -28,7 +28,7 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         value: Self::Item,
-    ) -> crate::PollSend<Self::Item> {
+    ) -> PollSend<Self::Item> {
         let this = self.project();
         let level = *this.level;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -61,19 +61,6 @@ pub trait Stream {
         }
     }
 
-    /// Returns a stream which produces a single value, and then is closed.
-    fn once(item: Self::Item) -> OnceStream<Self::Item> {
-        OnceStream::new(item)
-    }
-
-    /// Returns a stream which infiniately produces a clonable value.
-    fn repeat(item: Self::Item) -> RepeatStream<Self::Item>
-    where
-        Self::Item: Clone,
-    {
-        RepeatStream::new(item)
-    }
-
     /// Transforms the stream with a map function.
     fn map<Map, Into>(self, map: Map) -> MapStream<Self, Map, Into>
     where
@@ -155,6 +142,19 @@ where
     }
 }
 
+/// Returns a stream which produces a single value, and then is closed.
+pub fn once<T>(item: T) -> OnceStream<T> {
+    OnceStream::new(item)
+}
+
+/// Returns a stream which infiniately produces a clonable value.
+pub fn repeat<T>(item: T) -> RepeatStream<T>
+where
+    T: Clone,
+{
+    RepeatStream::new(item)
+}
+
 /// An enum of poll responses that are produced by Stream implementations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PollRecv<T> {
@@ -199,7 +199,7 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
 
-        let mut cx = cx.into();
+        let mut cx: crate::Context<'_> = cx.into();
         match Pin::new(this.recv).poll_recv(&mut cx) {
             PollRecv::Ready(v) => Poll::Ready(Some(v)),
             PollRecv::Pending => Poll::Pending,

--- a/src/stream/chain.rs
+++ b/src/stream/chain.rs
@@ -2,8 +2,8 @@ use std::pin::Pin;
 
 use atomic::{Atomic, Ordering};
 
+use crate::stream::{PollRecv, Stream};
 use crate::Context;
-use crate::{PollRecv, Stream};
 use pin_project::pin_project;
 
 #[derive(Copy, Clone)]
@@ -43,7 +43,7 @@ where
 {
     type Item = Left::Item;
 
-    fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> crate::PollRecv<Self::Item> {
+    fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> PollRecv<Self::Item> {
         let this = self.project();
         let mut state = this.state.load(Ordering::Acquire);
 
@@ -74,5 +74,58 @@ where
         }
 
         unreachable!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+
+    use crate::test::stream::*;
+    use crate::{
+        stream::{PollRecv, Stream},
+        Context,
+    };
+
+    use super::ChainStream;
+
+    #[test]
+    fn chain() {
+        let left = from_poll_iter(vec![PollRecv::Ready(1), PollRecv::Ready(2)]);
+        let right = from_poll_iter(vec![PollRecv::Ready(3)]);
+        let mut find = ChainStream::new(left, right);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Ready(1), Pin::new(&mut find).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Ready(2), Pin::new(&mut find).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Ready(3), Pin::new(&mut find).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Closed, Pin::new(&mut find).poll_recv(&mut cx));
+    }
+
+    #[test]
+    fn waits_for_right() {
+        let left = from_poll_iter(vec![PollRecv::Pending]);
+        let right = from_poll_iter(vec![PollRecv::Ready(1)]);
+        let mut find = ChainStream::new(left, right);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Pending, Pin::new(&mut find).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Ready(1), Pin::new(&mut find).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Closed, Pin::new(&mut find).poll_recv(&mut cx));
+    }
+
+    #[test]
+    fn ignores_after_close() {
+        let left = from_poll_iter(vec![PollRecv::Closed, PollRecv::Ready(1)]);
+        let right = from_poll_iter(vec![PollRecv::Closed, PollRecv::Ready(2)]);
+        let mut find = ChainStream::new(left, right);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Closed, Pin::new(&mut find).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Closed, Pin::new(&mut find).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Closed, Pin::new(&mut find).poll_recv(&mut cx));
     }
 }

--- a/src/stream/filter.rs
+++ b/src/stream/filter.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 
+use crate::stream::{PollRecv, Stream};
 use crate::Context;
-use crate::{PollRecv, Stream};
 
 pub struct FilterStream<From, Filter> {
     from: From,
@@ -25,13 +25,13 @@ where
 {
     type Item = From::Item;
 
-    fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> crate::PollRecv<Self::Item> {
+    fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> PollRecv<Self::Item> {
         let this = self.get_mut();
         loop {
             let from = Pin::new(&mut this.from);
             match from.poll_recv(cx) {
                 PollRecv::Ready(value) => {
-                    if !(this.filter)(&value) {
+                    if (this.filter)(&value) {
                         return PollRecv::Ready(value);
                     }
                 }
@@ -39,5 +39,50 @@ where
                 PollRecv::Closed => return PollRecv::Closed,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+
+    use crate::test::stream::*;
+    use crate::{
+        stream::{PollRecv, Stream},
+        Context,
+    };
+
+    use super::FilterStream;
+
+    #[test]
+    fn filter() {
+        let source = from_iter(vec![1, 2, 3, 4]);
+        let mut find = FilterStream::new(source, |i| i % 2 == 0);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Ready(2), Pin::new(&mut find).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Ready(4), Pin::new(&mut find).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Closed, Pin::new(&mut find).poll_recv(&mut cx));
+    }
+
+    #[test]
+    fn forward_pending() {
+        let source = pending::<usize>();
+        let mut find = FilterStream::new(source, |_| true);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Pending, Pin::new(&mut find).poll_recv(&mut cx));
+    }
+
+    #[test]
+    fn forward_closed() {
+        let source = closed::<usize>();
+        let mut find = FilterStream::new(source, |_| true);
+
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Closed, Pin::new(&mut find).poll_recv(&mut cx));
     }
 }

--- a/src/stream/repeat.rs
+++ b/src/stream/repeat.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 
+use crate::stream::{PollRecv, Stream};
 use crate::Context;
-use crate::{PollRecv, Stream};
 
 pub struct RepeatStream<T> {
     data: T,
@@ -22,7 +22,29 @@ where
 {
     type Item = T;
 
-    fn poll_recv(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> crate::PollRecv<Self::Item> {
+    fn poll_recv(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> PollRecv<Self::Item> {
         return PollRecv::Ready(self.data.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+
+    use crate::{
+        stream::{PollRecv, Stream},
+        Context,
+    };
+
+    use super::RepeatStream;
+
+    #[test]
+    fn test() {
+        let mut repeat = RepeatStream::new(1usize);
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Ready(1), Pin::new(&mut repeat).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Ready(1), Pin::new(&mut repeat).poll_recv(&mut cx));
+        assert_eq!(PollRecv::Ready(1), Pin::new(&mut repeat).poll_recv(&mut cx));
     }
 }

--- a/src/stream/stream_log.rs
+++ b/src/stream/stream_log.rs
@@ -1,8 +1,10 @@
-use crate::{Context, PollRecv, Stream};
+use crate::Context;
 use pin_project::pin_project;
 use std::{fmt::Debug, pin::Pin};
 
 use log::log;
+
+use super::{PollRecv, Stream};
 #[pin_project]
 pub struct StreamLog<S> {
     #[pin]
@@ -23,7 +25,7 @@ where
 {
     type Item = S::Item;
 
-    fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> crate::PollRecv<Self::Item> {
+    fn poll_recv(self: Pin<&mut Self>, cx: &mut Context<'_>) -> PollRecv<Self::Item> {
         let this = self.project();
         match this.stream.poll_recv(cx) {
             PollRecv::Ready(value) => {
@@ -33,5 +35,44 @@ where
             PollRecv::Pending => PollRecv::Pending,
             PollRecv::Closed => PollRecv::Closed,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+
+    use log::Level;
+
+    use crate::test::stream::*;
+    use crate::{
+        stream::{PollRecv, Stream},
+        Context,
+    };
+
+    use super::StreamLog;
+
+    #[test]
+    fn ready_forwarded() {
+        let mut repeat = StreamLog::new(ready(1usize), Level::Info);
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Ready(1), Pin::new(&mut repeat).poll_recv(&mut cx));
+    }
+
+    #[test]
+    fn pending_forwarded() {
+        let mut repeat = StreamLog::new(pending::<usize>(), Level::Info);
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Pending, Pin::new(&mut repeat).poll_recv(&mut cx));
+    }
+
+    #[test]
+    fn closed_forwarded() {
+        let mut repeat = StreamLog::new(closed::<usize>(), Level::Info);
+        let mut cx = Context::empty();
+
+        assert_eq!(PollRecv::Closed, Pin::new(&mut repeat).poll_recv(&mut cx));
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -64,6 +64,10 @@ impl<E> SenderShared<E> {
         self.inner.receiver_notify.notify();
     }
 
+    pub fn notify_self(&self) {
+        self.inner.sender_notify.notify();
+    }
+
     pub fn subscribe_recv(&self, cx: &Context<'_>) {
         self.inner.sender_notify.subscribe(cx);
     }

--- a/src/sync/transfer.rs
+++ b/src/sync/transfer.rs
@@ -1,6 +1,6 @@
 use atomic::{Atomic, Ordering};
 
-use crate::{Context, PollRecv};
+use crate::{stream::PollRecv, Context};
 
 use super::{
     notifier::Notifier,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,9 @@
+pub mod sink;
+pub mod stream;
 mod test_messages;
-
 pub use test_messages::*;
 
+use crate::Context;
 use std::time::Duration;
 
 pub const CHANNEL_TEST_ITERATIONS: usize = 2000;
@@ -10,7 +12,7 @@ pub const CHANNEL_TEST_RECEIVERS: usize = 5;
 pub const TEST_TIMEOUT: Duration = Duration::from_secs(100);
 
 pub fn noop_context() -> crate::Context<'static> {
-    futures_test::task::noop_context().into()
+    Context::empty()
 }
 
 pub fn panic_context() -> crate::Context<'static> {

--- a/src/test/sink.rs
+++ b/src/test/sink.rs
@@ -1,0 +1,142 @@
+#![allow(dead_code)]
+
+use pin_project::pin_project;
+use std::marker::PhantomData;
+
+use crate::sink::{PollSend, Sink};
+
+pub fn ready<T>() -> impl Sink<Item = T>
+where
+    T: Clone,
+{
+    ReadySink::new()
+}
+
+pub fn pending<T>() -> impl Sink<Item = T> {
+    PendingSink::new()
+}
+
+pub fn rejected<T>() -> impl Sink<Item = T> {
+    RejectedSink::new()
+}
+
+pub fn test_sink<T, I>(iter: I) -> TestSink<I::IntoIter, T>
+where
+    I: IntoIterator<Item = PollSend<T>>,
+    T: Clone,
+{
+    TestSink::new(iter.into_iter())
+}
+
+struct ReadySink<T> {
+    _t: PhantomData<T>,
+}
+
+impl<T> ReadySink<T> {
+    pub fn new() -> Self {
+        Self { _t: PhantomData }
+    }
+}
+
+impl<T> Sink for ReadySink<T> {
+    type Item = T;
+
+    fn poll_send(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut crate::Context<'_>,
+        _value: Self::Item,
+    ) -> crate::sink::PollSend<Self::Item> {
+        PollSend::Ready
+    }
+}
+
+struct PendingSink<T> {
+    _t: PhantomData<T>,
+}
+
+impl<T> PendingSink<T> {
+    pub fn new() -> Self {
+        Self { _t: PhantomData }
+    }
+}
+
+impl<T> Sink for PendingSink<T> {
+    type Item = T;
+
+    fn poll_send(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut crate::Context<'_>,
+        value: Self::Item,
+    ) -> PollSend<Self::Item> {
+        PollSend::Pending(value)
+    }
+}
+struct RejectedSink<T> {
+    _t: PhantomData<T>,
+}
+
+impl<T> RejectedSink<T> {
+    pub fn new() -> Self {
+        Self { _t: PhantomData }
+    }
+}
+
+impl<T> Sink for RejectedSink<T> {
+    type Item = T;
+
+    fn poll_send(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut crate::Context<'_>,
+        value: Self::Item,
+    ) -> PollSend<Self::Item> {
+        PollSend::Rejected(value)
+    }
+}
+#[pin_project]
+pub struct TestSink<I: Iterator, T> {
+    iter: I,
+    values: Vec<T>,
+}
+
+impl<I, T> TestSink<I, T>
+where
+    I: Iterator,
+    T: Clone,
+{
+    pub fn new(iter: I) -> Self {
+        Self {
+            iter,
+            values: Vec::new(),
+        }
+    }
+
+    pub fn values(&self) -> &[T] {
+        self.values.as_slice()
+    }
+}
+
+impl<I, T> Sink for TestSink<I, T>
+where
+    I: Iterator<Item = PollSend<T>>,
+    T: Clone,
+{
+    type Item = T;
+
+    fn poll_send(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut crate::Context<'_>,
+        value: Self::Item,
+    ) -> PollSend<Self::Item> {
+        let this = self.project();
+        let saved_value = value.clone();
+        match this.iter.next() {
+            Some(poll) => {
+                if let PollSend::Ready = poll {
+                    this.values.push(saved_value);
+                }
+                poll
+            }
+            None => PollSend::Rejected(value),
+        }
+    }
+}

--- a/src/test/stream.rs
+++ b/src/test/stream.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use pin_project::pin_project;
 use std::marker::PhantomData;
 

--- a/src/test/stream.rs
+++ b/src/test/stream.rs
@@ -1,0 +1,141 @@
+use pin_project::pin_project;
+use std::marker::PhantomData;
+
+use crate::stream::{PollRecv, Stream};
+
+pub fn ready<T>(value: T) -> impl Stream<Item = T>
+where
+    T: Clone,
+{
+    crate::stream::repeat(value)
+}
+
+pub fn pending<T>() -> impl Stream<Item = T> {
+    PendingStream::new()
+}
+
+pub fn closed<T>() -> impl Stream<Item = T> {
+    ClosedStream::new()
+}
+
+pub fn from_iter<I>(iter: I) -> impl Stream<Item = I::Item>
+where
+    I: IntoIterator,
+{
+    IterStream::new(iter.into_iter())
+}
+
+pub fn from_poll_iter<I, T>(iter: I) -> impl Stream<Item = T>
+where
+    I: IntoIterator<Item = PollRecv<T>>,
+{
+    PollIterStream::new(iter.into_iter())
+}
+
+struct PendingStream<T> {
+    _t: PhantomData<T>,
+}
+
+impl<T> PendingStream<T> {
+    pub fn new() -> Self {
+        Self { _t: PhantomData }
+    }
+}
+
+impl<T> Stream for PendingStream<T> {
+    type Item = T;
+
+    fn poll_recv(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut crate::Context<'_>,
+    ) -> crate::stream::PollRecv<Self::Item> {
+        PollRecv::Pending
+    }
+}
+struct ClosedStream<T> {
+    _t: PhantomData<T>,
+}
+
+impl<T> ClosedStream<T> {
+    pub fn new() -> Self {
+        Self { _t: PhantomData }
+    }
+}
+
+impl<T> Stream for ClosedStream<T> {
+    type Item = T;
+
+    fn poll_recv(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut crate::Context<'_>,
+    ) -> crate::stream::PollRecv<Self::Item> {
+        PollRecv::Closed
+    }
+}
+#[pin_project]
+pub struct IterStream<I: Iterator> {
+    iter: I,
+}
+
+impl<I> IterStream<I>
+where
+    I: Iterator,
+{
+    pub fn new(iter: I) -> Self {
+        Self { iter }
+    }
+}
+
+impl<I> Stream for IterStream<I>
+where
+    I: Iterator,
+{
+    type Item = I::Item;
+
+    fn poll_recv(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut crate::Context<'_>,
+    ) -> PollRecv<Self::Item> {
+        let this = self.project();
+        match this.iter.next() {
+            Some(value) => PollRecv::Ready(value),
+            None => PollRecv::Closed,
+        }
+    }
+}
+
+#[pin_project]
+pub struct PollIterStream<I: Iterator, T> {
+    iter: I,
+    _t: PhantomData<T>,
+}
+
+impl<I, T> PollIterStream<I, T>
+where
+    I: Iterator,
+{
+    pub fn new(iter: I) -> Self {
+        Self {
+            iter,
+            _t: PhantomData,
+        }
+    }
+}
+
+impl<I, T> Stream for PollIterStream<I, T>
+where
+    I: Iterator<Item = PollRecv<T>>,
+{
+    type Item = T;
+
+    fn poll_recv(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut crate::Context<'_>,
+    ) -> PollRecv<Self::Item> {
+        let this = self.project();
+        match this.iter.next() {
+            Some(poll) => poll,
+            None => PollRecv::Closed,
+        }
+    }
+}


### PR DESCRIPTION
- Add test coverage for the Sink and Stream combinators.
- Move Stream::repeat to postage::stream::repeat
- Move Stream::once to postage::stream::once
- Move Stream to postage::stream::Stream
- Move Sink to postage::sink::Sink