### PR TITLE
Significantly improve the performance of the broadcast channel by minimizing locks

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -13,7 +13,7 @@ mod debug_impl {
     pub fn enable_log() {
         LOG.call_once(|| {
             simple_logger::SimpleLogger::new()
-                .with_level(LevelFilter::Debug)
+                .with_level(LevelFilter::Info)
                 .init()
                 .unwrap();
         });


### PR DESCRIPTION
- Remove the head lock.  Replaced with a maintenance lock that is only acquired when subscribing, cloning, or dropping receivers.
- Reduce the usage of the RwLock in Slot.  It is now only acquired when actually attempting a read or write.  All 'pre-read' and 'pre-write' decisions are made using atomics.