### PR TITLE
Add an integration with the futures crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,15 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pin-project = "1"
-crossbeam-queue = "0.3"
 atomic = "0.5"
+crossbeam-queue = "0.3"
+log = { version = "0.4", optional = true }
+futures = { version = "0.3", optional = true, default-features = false }
+pin-project = "1"
+pollster = { version = "0.2", optional = true }
+simple_logger = { version = "1.11.0", optional = true }
 static_assertions = "1.1.0"
 thiserror = "1.0"
-pollster = { version = "0.2", optional = true }
-log = { version = "0.4", optional = true }
-simple_logger = { version = "1.11.0", optional = true }
 
 [dev-dependencies]
 futures-test = "0.3"
@@ -64,6 +65,8 @@ harness = false
 
 [features]
 default = ["logging", "blocking"]
+# enables futures Sink and Stream implementations
+futures-traits = ["futures"]
 # enables combinators that log their messages
 logging = ["log"]
 # enables debug log statements.  disabled by default in production builds as they are *very verbose*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   **|** [watch](https://docs.rs/postage/latest/postage/watch/index.html) 
 - Works with **any executor.**
   - Currently regressions are written for `tokio` and `async-std`.
+  - With the `futures-traits` feature, channels implement the futures `Sink/Stream` traits.
 - **Throughly tested.**  
   - Channels have full unit test coverage, and integration test coverage with multiple async executors.
 - Includes **built-in [Stream](https://docs.rs/postage/latest/postage/stream/trait.Stream.html) and [Sink](https://docs.rs/postage/latest/postage/sink/trait.Sink.html) combinators.** 

--- a/src/channels/broadcast.rs
+++ b/src/channels/broadcast.rs
@@ -33,6 +33,8 @@ pub fn channel<T: Clone>(capacity: usize) -> (Sender<T>, Receiver<T>) {
 /// A broadcast sender that can be used with the postage::Sink trait.  Can be cloned.
 ///
 /// The sender task is suspended when the internal buffer is filled.
+///
+/// Note: no implementation of the `futures::Sink` trait is provided for the broadcast Sender.
 pub struct Sender<T> {
     pub(in crate::channels::broadcast) shared: SenderShared<MpmcCircularBuffer<T>>,
 }

--- a/src/channels/dispatch.rs
+++ b/src/channels/dispatch.rs
@@ -77,6 +77,65 @@ impl<T> Sink for Sender<T> {
     }
 }
 
+#[cfg(feature = "futures-traits")]
+mod impl_futures {
+    use crate::sink::SendError;
+    use std::task::Poll;
+
+    impl<T> futures::sink::Sink<T> for super::Sender<T> {
+        type Error = SendError<()>;
+
+        fn poll_ready(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            loop {
+                if self.shared.is_closed() {
+                    return Poll::Ready(Err(SendError(())));
+                }
+
+                let queue = &self.shared.extension().queue;
+                let guard = self.shared.recv_guard();
+
+                if queue.is_full() {
+                    let mut cx = cx.into();
+                    self.shared.subscribe_recv(&mut cx);
+
+                    if guard.is_expired() {
+                        continue;
+                    }
+
+                    return Poll::Pending;
+                } else {
+                    return Poll::Ready(Ok(()));
+                }
+            }
+        }
+
+        fn start_send(self: std::pin::Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+            self.shared
+                .extension()
+                .queue
+                .push(item)
+                .map_err(|_t| SendError(()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+}
+
 impl<T> Sender<T> {
     pub fn subscribe(&self) -> Receiver<T> {
         Receiver {

--- a/src/channels/dispatch.rs
+++ b/src/channels/dispatch.rs
@@ -113,11 +113,18 @@ mod impl_futures {
         }
 
         fn start_send(self: std::pin::Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
-            self.shared
+            let result = self
+                .shared
                 .extension()
                 .queue
                 .push(item)
-                .map_err(|_t| SendError(()))
+                .map_err(|_t| SendError(()));
+
+            if result.is_ok() {
+                self.shared.notify_receivers();
+            }
+
+            result
         }
 
         fn poll_flush(

--- a/src/channels/mpsc.rs
+++ b/src/channels/mpsc.rs
@@ -74,6 +74,65 @@ impl<T> Sink for Sender<T> {
     }
 }
 
+#[cfg(feature = "futures-traits")]
+mod impl_futures {
+    use crate::sink::SendError;
+    use std::task::Poll;
+
+    impl<T> futures::sink::Sink<T> for super::Sender<T> {
+        type Error = SendError<()>;
+
+        fn poll_ready(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            loop {
+                if self.shared.is_closed() {
+                    return Poll::Ready(Err(SendError(())));
+                }
+
+                let queue = &self.shared.extension().queue;
+                let guard = self.shared.recv_guard();
+
+                if queue.is_full() {
+                    let mut cx = cx.into();
+                    self.shared.subscribe_recv(&mut cx);
+
+                    if guard.is_expired() {
+                        continue;
+                    }
+
+                    return Poll::Pending;
+                } else {
+                    return Poll::Ready(Ok(()));
+                }
+            }
+        }
+
+        fn start_send(self: std::pin::Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+            self.shared
+                .extension()
+                .queue
+                .push(item)
+                .map_err(|_t| SendError(()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+}
+
 /// The receiver half of an mpsc channel.  Cannot be cloned.
 ///
 /// Can receive messages with the postage::Stream trait.

--- a/src/channels/mpsc.rs
+++ b/src/channels/mpsc.rs
@@ -110,11 +110,18 @@ mod impl_futures {
         }
 
         fn start_send(self: std::pin::Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
-            self.shared
+            let result = self
+                .shared
                 .extension()
                 .queue
                 .push(item)
-                .map_err(|_t| SendError(()))
+                .map_err(|_t| SendError(()));
+
+            if result.is_ok() {
+                self.shared.notify_receivers();
+            }
+
+            result
         }
 
         fn poll_flush(

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -1,0 +1,184 @@
+use std::task::Poll;
+
+macro_rules! poll {
+    ($self:ident, $cx:ident) => {{
+        use crate::context::Context;
+        use crate::prelude::Stream;
+
+        let mut cx = Context::from_waker($cx.waker());
+
+        return match $self.poll_recv(&mut cx) {
+            crate::stream::PollRecv::Ready(v) => Poll::Ready(Some(v)),
+            crate::stream::PollRecv::Pending => Poll::Pending,
+            crate::stream::PollRecv::Closed => Poll::Ready(None),
+        };
+    }};
+}
+
+impl futures::stream::Stream for crate::barrier::Receiver {
+    type Item = ();
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        poll!(self, cx)
+    }
+}
+
+impl<T: Clone> futures::stream::Stream for crate::broadcast::Receiver<T> {
+    type Item = T;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        poll!(self, cx)
+    }
+}
+
+impl<T> futures::stream::Stream for crate::dispatch::Receiver<T> {
+    type Item = T;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        poll!(self, cx)
+    }
+}
+
+impl<T> futures::stream::Stream for crate::mpsc::Receiver<T> {
+    type Item = T;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        poll!(self, cx)
+    }
+}
+
+impl<T> futures::stream::Stream for crate::oneshot::Receiver<T> {
+    type Item = T;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        poll!(self, cx)
+    }
+}
+
+impl<T: Clone> futures::stream::Stream for crate::watch::Receiver<T> {
+    type Item = T;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        poll!(self, cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{pin::Pin, task::Poll};
+
+    use crate::{
+        barrier, broadcast, dispatch, mpsc, oneshot,
+        sink::{PollSend, Sink},
+        watch,
+    };
+    use futures::Stream;
+
+    macro_rules! test_stream {
+        ($chan:expr, $val:expr) => {
+            let mut std_cx = futures_test::task::noop_context();
+            let mut cx = crate::test::noop_context();
+
+            let (mut tx, mut rx) = $chan;
+            assert_eq!(Poll::Pending, Pin::new(&mut rx).poll_next(&mut std_cx));
+
+            assert_eq!(PollSend::Ready, Pin::new(&mut tx).poll_send(&mut cx, $val));
+
+            assert_eq!(
+                Poll::Ready(Some($val)),
+                Pin::new(&mut rx).poll_next(&mut std_cx)
+            );
+
+            drop(tx);
+
+            assert_eq!(Poll::Ready(None), Pin::new(&mut rx).poll_next(&mut std_cx));
+        };
+    }
+
+    #[test]
+    fn barrier() {
+        let mut std_cx = futures_test::task::noop_context();
+        let mut cx = crate::test::noop_context();
+
+        let (mut tx, mut rx) = barrier::channel();
+        assert_eq!(Poll::Pending, Pin::new(&mut rx).poll_next(&mut std_cx));
+
+        assert_eq!(PollSend::Ready, Pin::new(&mut tx).poll_send(&mut cx, ()));
+
+        assert_eq!(
+            Poll::Ready(Some(())),
+            Pin::new(&mut rx).poll_next(&mut std_cx)
+        );
+
+        drop(tx);
+
+        assert_eq!(
+            Poll::Ready(Some(())),
+            Pin::new(&mut rx).poll_next(&mut std_cx)
+        );
+    }
+
+    #[test]
+    fn broadcast() {
+        test_stream!(broadcast::channel(4), 1usize);
+    }
+
+    #[test]
+    fn dispatch() {
+        test_stream!(dispatch::channel(4), 1usize);
+    }
+
+    #[test]
+    fn mpsc() {
+        test_stream!(mpsc::channel(4), 1usize);
+    }
+
+    #[test]
+    fn oneshot() {
+        test_stream!(oneshot::channel(), 1usize);
+    }
+
+    #[test]
+    fn watch() {
+        let mut std_cx = futures_test::task::noop_context();
+        let mut cx = crate::test::noop_context();
+
+        let (mut tx, mut rx) = watch::channel();
+        assert_eq!(
+            Poll::Ready(Some(0usize)),
+            Pin::new(&mut rx).poll_next(&mut std_cx)
+        );
+
+        assert_eq!(
+            PollSend::Ready,
+            Pin::new(&mut tx).poll_send(&mut cx, 1usize)
+        );
+
+        assert_eq!(
+            Poll::Ready(Some(1usize)),
+            Pin::new(&mut rx).poll_next(&mut std_cx)
+        );
+
+        drop(tx);
+
+        assert_eq!(Poll::Ready(None), Pin::new(&mut rx).poll_next(&mut std_cx));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //!   - `watch`, a state distribution channel with a value that can be borrowed.
 //! - Works with **any executor.**
 //!   - Currently regressions are written for `tokio` and `async-std`.
+//!   - With the `futures-traits` feature, channels implement the futures `Sink/Stream` traits.
 //! - **Throughly tested.**  
 //!   - Channels have full unit test coverage, and integration test coverage with multiple async executors.
 //! - Comes with **built-in Stream and Sink combinators.**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,9 @@ pub mod sink;
 pub mod stream;
 mod sync;
 
+#[cfg(feature = "futures-traits")]
+mod futures;
+
 pub use channels::barrier;
 pub use channels::broadcast;
 pub use channels::dispatch;


### PR DESCRIPTION
Implement futures::Sink and futures::Stream for all senders and receivers if the `futures-traits` feature is enabled.

No implementation of `futures::Sink` is provided for the `broadcast::Sender`.