### PR TITLE
Implement Debug for Sender & Receiver types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /target
 Cargo.lock
 .vscode

--- a/src/channels/barrier.rs
+++ b/src/channels/barrier.rs
@@ -2,6 +2,7 @@
 //!
 //! The barrier can also be triggered with `tx.send(())`.
 
+use std::fmt;
 use std::sync::Arc;
 
 use atomic::{Atomic, Ordering};
@@ -38,7 +39,7 @@ pub struct Sender {
     pub(in crate::channels::barrier) shared: Arc<Shared>,
 }
 
-assert_impl_all!(Sender: Send, Sync);
+assert_impl_all!(Sender: Send, Sync, fmt::Debug);
 assert_not_impl_all!(Sender: Clone);
 
 impl Sink for Sender {
@@ -56,6 +57,12 @@ impl Sink for Sender {
             }
             State::Sent => PollSend::Rejected(()),
         }
+    }
+}
+
+impl fmt::Debug for Sender {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender").finish()
     }
 }
 
@@ -117,7 +124,7 @@ pub struct Receiver {
     pub(in crate::channels::barrier) shared: Arc<Shared>,
 }
 
-assert_impl_all!(Receiver: Clone, Send, Sync);
+assert_impl_all!(Receiver: Clone, Send, Sync, fmt::Debug);
 
 #[derive(Copy, Clone)]
 enum State {
@@ -156,6 +163,12 @@ impl Stream for Receiver {
             }
             State::Sent => PollRecv::Ready(()),
         }
+    }
+}
+
+impl fmt::Debug for Receiver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Receiver").finish()
     }
 }
 

--- a/src/channels/broadcast.rs
+++ b/src/channels/broadcast.rs
@@ -3,6 +3,8 @@
 //! When a receiver is cloned, the new receive will observe the same series of messages as the original.
 //! When a receiver is created with `Sender::subscribe`, it will observe new messages.
 
+use std::fmt;
+
 use super::SendMessage;
 use static_assertions::assert_impl_all;
 
@@ -50,7 +52,7 @@ impl<T> Clone for Sender<T> {
     }
 }
 
-assert_impl_all!(Sender<SendMessage>: Send, Sync, Clone);
+assert_impl_all!(Sender<SendMessage>: Send, Sync, Clone, fmt::Debug);
 
 impl<T> Sink for Sender<T>
 where
@@ -98,6 +100,12 @@ impl<T> Sender<T> {
     }
 }
 
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender").finish()
+    }
+}
+
 /// A broadcast receiver that can be used with the postage::Stream trait.
 ///
 /// When cloned, the new receiver will begin processing messages at the same location as the original.
@@ -109,7 +117,7 @@ pub struct Receiver<T> {
 unsafe impl<T: Send> Send for Receiver<T> {}
 unsafe impl<T: Send> Sync for Receiver<T> {}
 
-assert_impl_all!(Receiver<SendMessage>: Send, Sync, Clone);
+assert_impl_all!(Receiver<SendMessage>: Send, Sync, Clone, fmt::Debug);
 
 impl<T> Receiver<T> {
     fn new(shared: ReceiverShared<MpmcCircularBuffer<T>>, reader: BufferReader) -> Self {
@@ -160,6 +168,12 @@ impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         let buffer = self.shared.extension();
         self.reader.drop_with(buffer);
+    }
+}
+
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Receiver").finish()
     }
 }
 

--- a/src/channels/dispatch.rs
+++ b/src/channels/dispatch.rs
@@ -4,6 +4,8 @@
 //!
 //! The producer can be cloned, and the sender task is suspended if the channel becomes full.
 
+use std::fmt;
+
 use super::SendMessage;
 use crate::{
     sink::{PollSend, Sink},
@@ -32,7 +34,7 @@ pub struct Sender<T> {
     shared: SenderShared<StateExtension<T>>,
 }
 
-assert_impl_all!(Sender<String>: Clone, Send, Sync);
+assert_impl_all!(Sender<String>: Clone, Send, Sync, fmt::Debug);
 
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Self {
@@ -74,6 +76,12 @@ impl<T> Sink for Sender<T> {
                 }
             }
         }
+    }
+}
+
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender").finish()
     }
 }
 
@@ -158,7 +166,7 @@ pub struct Receiver<T> {
     shared: ReceiverShared<StateExtension<T>>,
 }
 
-assert_impl_all!(Receiver<SendMessage>: Clone, Send, Sync);
+assert_impl_all!(Receiver<SendMessage>: Clone, Send, Sync, fmt::Debug);
 
 impl<T> Stream for Receiver<T> {
     type Item = T;
@@ -196,6 +204,12 @@ impl<T> Clone for Receiver<T> {
         Self {
             shared: self.shared.clone(),
         }
+    }
+}
+
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Receiver").finish()
     }
 }
 

--- a/src/channels/mpsc.rs
+++ b/src/channels/mpsc.rs
@@ -2,6 +2,8 @@
 //!
 //! The producer can be cloned, and the sender task is suspended if the channel becomes full.
 
+use std::fmt;
+
 use super::SendMessage;
 use crate::{
     sink::{PollSend, Sink},
@@ -29,7 +31,7 @@ pub struct Sender<T> {
     pub(in crate::channels::mpsc) shared: SenderShared<StateExtension<T>>,
 }
 
-assert_impl_all!(Sender<String>: Clone, Send, Sync);
+assert_impl_all!(Sender<String>: Clone, Send, Sync, fmt::Debug);
 
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Self {
@@ -71,6 +73,12 @@ impl<T> Sink for Sender<T> {
                 }
             }
         }
+    }
+}
+
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender").finish()
     }
 }
 
@@ -147,7 +155,7 @@ pub struct Receiver<T> {
     pub(in crate::channels::mpsc) shared: ReceiverShared<StateExtension<T>>,
 }
 
-assert_impl_all!(Receiver<SendMessage>: Send, Sync);
+assert_impl_all!(Receiver<SendMessage>: Send, Sync, fmt::Debug);
 assert_not_impl_all!(Receiver<SendMessage>: Clone);
 
 impl<T> Stream for Receiver<T> {
@@ -179,6 +187,12 @@ impl<T> Stream for Receiver<T> {
                 }
             }
         }
+    }
+}
+
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Receiver").finish()
     }
 }
 

--- a/src/channels/oneshot.rs
+++ b/src/channels/oneshot.rs
@@ -1,6 +1,7 @@
 //! Oneshot channels transmit a single value between a sender and a reciever.  
 //!
 //! Neither can be cloned.  If the sender drops, the receiver recieves a `None` value.
+use std::fmt;
 use std::sync::Arc;
 
 use super::SendMessage;
@@ -31,7 +32,7 @@ pub struct Sender<T> {
     pub(in crate::channels::oneshot) shared: Arc<Transfer<T>>,
 }
 
-assert_impl_all!(Sender<SendMessage>: Send, Sync);
+assert_impl_all!(Sender<SendMessage>: Send, Sync, fmt::Debug);
 assert_not_impl_all!(Sender<SendMessage>: Clone);
 
 impl<T> Sink for Sender<T> {
@@ -46,6 +47,12 @@ impl<T> Sink for Sender<T> {
             Ok(_) => PollSend::Ready,
             Err(v) => PollSend::Rejected(v),
         }
+    }
+}
+
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender").finish()
     }
 }
 
@@ -95,7 +102,7 @@ pub struct Receiver<T> {
     pub(in crate::channels::oneshot) shared: Arc<Transfer<T>>,
 }
 
-assert_impl_all!(Sender<SendMessage>: Send, Sync);
+assert_impl_all!(Sender<SendMessage>: Send, Sync, fmt::Debug);
 assert_not_impl_all!(Sender<SendMessage>: Clone);
 
 impl<T> Stream for Receiver<T> {
@@ -112,6 +119,12 @@ impl<T> Stream for Receiver<T> {
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         self.shared.receiver_disconnect();
+    }
+}
+
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Receiver").finish()
     }
 }
 

--- a/src/channels/watch.rs
+++ b/src/channels/watch.rs
@@ -6,6 +6,7 @@
 
 use super::SendSyncMessage;
 use std::{
+    fmt,
     ops::{Deref, DerefMut},
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -47,7 +48,7 @@ pub struct Sender<T> {
     pub(in crate::channels::watch) shared: SenderShared<StateExtension<T>>,
 }
 
-assert_impl_all!(Sender<SendSyncMessage>: Send, Sync);
+assert_impl_all!(Sender<SendSyncMessage>: Send, Sync, fmt::Debug);
 assert_not_impl_all!(Sender<SendSyncMessage>: Clone);
 
 impl<T> Sink for Sender<T> {
@@ -89,6 +90,12 @@ impl<T> Sender<T> {
         let lock = extension.value.read().unwrap();
 
         Ref { lock }
+    }
+}
+
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender").finish()
     }
 }
 
@@ -147,7 +154,7 @@ pub struct Receiver<T> {
     pub(in crate::channels::watch) generation: AtomicUsize,
 }
 
-assert_impl_all!(Receiver<SendSyncMessage>: Clone, Send, Sync);
+assert_impl_all!(Receiver<SendSyncMessage>: Clone, Send, Sync, fmt::Debug);
 
 impl<T> Stream for Receiver<T>
 where
@@ -213,6 +220,12 @@ impl<T> Clone for Receiver<T> {
             shared: self.shared.clone(),
             generation: AtomicUsize::new(0),
         }
+    }
+}
+
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Receiver").finish()
     }
 }
 


### PR DESCRIPTION
I noticed the types in this crate are missing a `Debug` implementation, but I need them to have one in order to use them in a struct that derives `Debug`. So I went ahead and added a basic implementation for the `Sender` and `Receiver` structs of each channel type. 

I've opted for displaying them as empty structs since the internals of these channels also don't implement `Debug` (so a simple derive wasn't possible) and I think the internal implementation doesn't need to be exposed regardless.