### PR TITLE
Documentation for v0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
 /target
+/local
 Cargo.lock
 .vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,16 @@ repository = "https://github.com/austinjones/postage-rs"
 license = "MIT"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["logging", "blocking"]
+# enables blocking send and receive
+blocking = ["pollster"]
+# enables debug log statements.  disabled by default in production builds as they are *very verbose*
+debug = ["log", "simple_logger"]
+# enables futures Sink and Stream implementations
+futures-traits = ["futures"]
+# enables combinators that log their messages
+logging = ["log"]
 
 [dependencies]
 atomic = "0.5"
@@ -62,23 +71,3 @@ harness = false
 [[bench]]
 name = "async_std_channel"
 harness = false
-
-
-[features]
-default = ["logging", "blocking"]
-# enables blocking send and receive
-blocking = ["pollster"]
-# enables debug log statements.  disabled by default in production builds as they are *very verbose*
-debug = ["log", "simple_logger"]
-# enables futures Sink and Stream implementations
-futures-traits = ["futures"]
-# enables combinators that log their messages
-logging = ["log"]
-
-
-
-# [[example]]
-# name = "tokio"
-
-# [[example]]
-# name = "async-std"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Austin Jones
+Copyright (c) 2022 Austin Jones
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -56,16 +56,16 @@ Benchmarks of postage channels, and comparable async-std/tokio channels.
 
 All benchmarks were taken with criterion and are in the `benches` directory.
 
-| Package   | Channel   | send/recv    | send full | recv empty |
-| --------- | --------- | ------------ | --------- | ---------- |
-| broadcast | postage   | 144ns        | 6ns       | 7ns        |
-| broadcast | tokio     | 88ns (-38%)  | 49ns      | 39ns       |
-| -         |           |              |           |            |
-| dispatch  | postage   | 87ns         | 26ns      | 26ns       |
-| dispatch  | async_std | 41ns (-52%)  | 10ns      | 10ns       |
-| -         |           |              |           |            |
-| mpsc      | postage   | 79ns         | 25ns      | 27ns       |
-| mpsc      | tokio     | 132ns (+67%) | 1ns       | 31ns       |
-| -         |           |              |           |            |
-| watch     | postage   | 96ns         | -         | 7ns        |
-| watch     | tokio     | 74ns (-22%)  | -         | 75ns       |
+| Package   | Channel   | send/recv   | send full | recv empty |
+| --------- | --------- | ----------- | --------- | ---------- |
+| broadcast | postage   | 114ns       | 7ns       | 8ns        |
+| broadcast | tokio     | 98ns (-14%) | 54ns      | 37ns       |
+| -         |           |             |           |            |
+| dispatch  | postage   | 80ns        | 26ns      | 25ns       |
+| dispatch  | async_std | 41ns (-48%) | 10ns      | 11ns       |
+| -         |           |             |           |            |
+| mpsc      | postage   | 83ns        | 27ns      | 30ns       |
+| mpsc      | tokio     | 85ns (+1%)  | 2ns       | 35ns       |
+| -         |           |             |           |            |
+| watch     | postage   | 96ns        | -         | 7ns        |
+| watch     | tokio     | 73ns (-23%) | -         | 75ns       |

--- a/examples/async_std.rs
+++ b/examples/async_std.rs
@@ -1,0 +1,15 @@
+use postage::{mpsc, prelude::Stream, sink::Sink};
+
+#[async_std::main]
+async fn main() {
+    let (mut tx, mut rx) = mpsc::channel(8);
+
+    async_std::task::spawn(async move {
+        tx.send("Hello".to_string()).await.ok();
+        tx.send("World".to_string()).await.ok();
+    });
+
+    while let Some(message) = rx.recv().await {
+        println!("Sender says {}", message)
+    }
+}

--- a/examples/channel_barrier.rs
+++ b/examples/channel_barrier.rs
@@ -1,0 +1,20 @@
+use std::time::Duration;
+
+use postage::{barrier, prelude::Stream};
+
+#[tokio::main]
+async fn main() {
+    // Barriers are synchronization tools.
+    // They don't carry a value, but instead mark an event.
+    // When the sender is dropped, the channel fires.
+    let (tx, mut rx) = barrier::channel();
+
+    tokio::task::spawn(async move {
+        // move tx into this task
+        let _tx = tx;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    });
+
+    rx.recv().await;
+    println!("OK, I'm ready.")
+}

--- a/examples/channel_broadcast.rs
+++ b/examples/channel_broadcast.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use postage::{broadcast, prelude::Stream, sink::Sink};
+
+#[tokio::main]
+async fn main() {
+    // Broadcast channels are bounded multi-producer, multi-consumer channels.
+    // Each reciever will observe every message created after the receiver.
+    // Let's send two messages from multiple senders
+    let (mut tx, rx) = broadcast::channel::<usize>(8);
+
+    let mut tx2 = tx.clone();
+    let rx2 = rx.clone();
+
+    // Alice and Bob will see both messages
+    tokio::task::spawn(print_messages("alice", rx));
+    tokio::task::spawn(print_messages("bob", rx2));
+
+    tx.send(0).await.ok();
+
+    // Charlie will only see the last message
+    let rx3 = tx.subscribe();
+    tokio::task::spawn(print_messages("charlie", rx3));
+    tx2.send(1).await.ok();
+
+    // Wait for all the receivers to print
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}
+
+async fn print_messages(name: &'static str, mut rx: impl Stream<Item = usize> + Unpin) {
+    while let Some(message) = rx.recv().await {
+        println!("{} got a message: {}", name, message);
+    }
+}

--- a/examples/channel_dispatch.rs
+++ b/examples/channel_dispatch.rs
@@ -1,0 +1,25 @@
+use postage::{dispatch, prelude::Stream, sink::Sink};
+
+#[tokio::main]
+async fn main() {
+    // Dispatch channels are fixed-capacity multi-producer multi-consumer queues.
+    // Messages are taken from the channel, rather than cloned (like the broadcast channel)
+    let (mut tx, mut rx) = dispatch::channel::<usize>(8);
+
+    let mut rx2 = rx.clone();
+
+    // Alice and Bob will see both messages
+    tx.send(0).await.ok();
+    tx.send(1).await.ok();
+    tx.send(2).await.ok();
+
+    read_message("alice", &mut rx).await;
+    read_message("bob", &mut rx2).await;
+    read_message("alice", &mut rx).await;
+}
+
+async fn read_message(name: &'static str, mut rx: impl Stream<Item = usize> + Unpin) {
+    if let Some(message) = rx.recv().await {
+        println!("{} got a message: {}", name, message);
+    }
+}

--- a/examples/channel_mpsc.rs
+++ b/examples/channel_mpsc.rs
@@ -1,0 +1,24 @@
+use postage::{mpsc, prelude::Stream, sink::Sink};
+
+#[tokio::main]
+async fn main() {
+    // Postage provides a standard multi-producer, single-consumer queue.
+    let (mut tx, mut rx) = mpsc::channel::<usize>(8);
+
+    let mut tx2 = tx.clone();
+
+    // Alice and Bob will see both messages
+    tx.send(0).await.ok();
+    tx2.send(1).await.ok();
+    tx.send(2).await.ok();
+
+    read_message("alice", &mut rx).await;
+    read_message("alice", &mut rx).await;
+    read_message("alice", &mut rx).await;
+}
+
+async fn read_message(name: &'static str, mut rx: impl Stream<Item = usize> + Unpin) {
+    if let Some(message) = rx.recv().await {
+        println!("{} got a message: {}", name, message);
+    }
+}

--- a/examples/channel_oneshot.rs
+++ b/examples/channel_oneshot.rs
@@ -1,0 +1,12 @@
+use postage::{oneshot, prelude::Stream, sink::Sink};
+
+#[tokio::main]
+async fn main() {
+    // Postage provides a standard oneshot channel.
+    let (mut tx, mut rx) = oneshot::channel::<usize>();
+
+    // Alice and Bob will see both messages
+    tx.send(0).await.ok();
+
+    println!("alice got a message: {:?}", rx.recv().await);
+}

--- a/examples/channel_watch.rs
+++ b/examples/channel_watch.rs
@@ -1,0 +1,47 @@
+use postage::{prelude::Stream, sink::Sink, watch};
+
+#[tokio::main]
+async fn main() {
+    // Postage provides a watch channel, similar to the tokio watch channel.
+    // Watch channels store a single value, and receivers subscribe to updates.
+    // When receivers are initially created, they observe the stored value.
+
+    // There are a few ways of constructing watch channels:
+
+    // This constructs a channel with T::default() - in this case 0
+    let (_tx, mut rx) = watch::channel::<usize>();
+    assert_eq!(Some(0), rx.recv().await);
+
+    // You can provide an initial value
+    let (_tx, mut rx) = watch::channel_with(42);
+    assert_eq!(Some(42), rx.recv().await);
+
+    // You can also construct a channel with Option<T>, which implements Default.
+    // Let's keep track of all the cookie boxes we sent to Alice in a Vec!
+    let (mut tx, mut rx) = watch::channel_with_option::<Vec<usize>>();
+
+    // since rx observes the initial value, we will get a None message
+    assert_eq!(Some(None), rx.recv().await);
+
+    tx.send(Some(vec![4])).await.ok();
+    assert_eq!(Some(Some(vec![4])), rx.recv().await);
+
+    // You can borrow the contained value in the sender and receiver:
+    // This blocks the channel, so keep it short!
+    {
+        let mut value = tx.borrow_mut();
+        if let Some(vec) = value.as_mut() {
+            vec.push(12);
+        }
+    }
+
+    // Receivers will get a message with the update
+    assert_eq!(Some(Some(vec![4, 12])), rx.recv().await);
+
+    // Receivers can also can borrow the current value:
+    let cookie_data = rx.borrow();
+    if let Some(value) = cookie_data.as_ref() {
+        let total: usize = value.iter().copied().sum();
+        println!("Alice has this many cookies: {}", total)
+    }
+}

--- a/examples/combinators.rs
+++ b/examples/combinators.rs
@@ -1,0 +1,26 @@
+use postage::{mpsc, oneshot, prelude::Stream, sink::Sink};
+
+#[derive(Debug)]
+enum Message {
+    Str(&'static str),
+    Code(usize),
+}
+
+#[tokio::main]
+async fn main() {
+    let (mut tx_a, rx_a) = mpsc::channel(8);
+    let (mut tx_b, rx_b) = oneshot::channel();
+
+    tx_a.send("Hello!").await.ok();
+    tx_b.send(0usize).await.ok();
+
+    let mut rx = rx_a
+        // map the first reciever to a common enum type
+        .map(|a| Message::Str(a))
+        // map the 2nd receiver to the enum type, and then merge it with the first
+        .merge(rx_b.map(|b| Message::Code(b)));
+
+    while let Some(message) = rx.recv().await {
+        println!("Sender says {:?}", message)
+    }
+}

--- a/examples/generics.rs
+++ b/examples/generics.rs
@@ -1,0 +1,35 @@
+use postage::{
+    mpsc,
+    prelude::Stream,
+    sink::{SendError, Sink},
+};
+
+#[tokio::main]
+async fn main() {
+    let (mut tx, rx) = mpsc::channel(8);
+
+    tokio::task::spawn(async move {
+        send_message(&mut tx, "Hello!").await.ok();
+        send_message(&mut tx, "Helooooo!").await.ok();
+        if let Err(e) = send_message(tx, "This is important").await {
+            println!("Failed to send a message to the receiver: {}", e);
+        }
+    });
+
+    // consumes rx, and prints all the message that the channel emits
+    print_messages(rx).await;
+}
+
+/// impl Trait can be used to pass channel endpoints to functions
+async fn send_message(
+    mut tx: impl Sink<Item = String> + Unpin,
+    message: &str,
+) -> Result<(), SendError<String>> {
+    tx.send(message.to_string() + " world!").await
+}
+
+async fn print_messages(mut rx: impl Stream<Item = String> + Unpin) {
+    while let Some(message) = rx.recv().await {
+        println!("Sender says {}", message)
+    }
+}

--- a/examples/sinks.rs
+++ b/examples/sinks.rs
@@ -1,0 +1,36 @@
+use postage::{
+    mpsc,
+    sink::{Sink, TrySendError},
+};
+
+#[tokio::main]
+async fn main() {
+    // Channel senders require mutable references to take messages.
+    let (mut tx, rx) = mpsc::channel(8);
+
+    // Senders are fallible.  If a channel is closed, there is nowhere to send the message.
+    // If you want to ignore the error, you can use Result::ok
+    tx.send("Hello!").await.ok();
+
+    // If you want to check for an error, you can recover the message with `if let`
+    // Let's drop rx to trigger the error.
+    drop(rx);
+
+    if let Err(message) = tx.send("This is important").await {
+        println!("Failed to send a message to the receiver: {}", message);
+    }
+
+    // You can also try to send a message without blocking:
+    match tx.try_send("You there?") {
+        Ok(()) => {
+            // the message was sent!
+        }
+        Err(TrySendError::Pending(_message)) => {
+            // the message was returned, but it might be accepted later
+        }
+        Err(TrySendError::Rejected(_message)) => {
+            // the message was rejected.
+            // the channel will never accept this message.
+        }
+    }
+}

--- a/examples/streams.rs
+++ b/examples/streams.rs
@@ -1,0 +1,37 @@
+use postage::{mpsc, prelude::Stream, sink::Sink, stream::TryRecvError};
+
+#[tokio::main]
+async fn main() {
+    // Channel receivers require mutable references to take messages.
+    let mut rx = create_stream().await;
+
+    // There are a few ways to iterate over streams.
+    // You can pull a single message out:
+    if let Some(message) = rx.recv().await {
+        println!("We got a message: {}", message);
+    }
+
+    // You can also iterate over all the messages, until the channel runs out:
+    while let Some(message) = rx.recv().await {
+        println!("We got a message: {}", message);
+    }
+
+    // You can attempt to pull a value from the stream without blocking:
+    match rx.try_recv() {
+        Ok(message) => println!("We got a message: {}", message),
+        Err(TryRecvError::Pending) => {
+            // there may be a message in the future
+        }
+        Err(TryRecvError::Closed) => {
+            // the channel is closed.
+        }
+    }
+}
+
+async fn create_stream() -> impl Stream<Item = String> {
+    let (mut tx, rx) = mpsc::channel(8);
+    tx.send("Hello!".to_string()).await.ok();
+    tx.send("World!".to_string()).await.ok();
+
+    rx
+}

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -1,0 +1,15 @@
+use postage::{mpsc, prelude::Stream, sink::Sink};
+
+#[tokio::main]
+async fn main() {
+    let (mut tx, mut rx) = mpsc::channel(8);
+
+    tokio::task::spawn(async move {
+        tx.send("Hello".to_string()).await.ok();
+        tx.send("World".to_string()).await.ok();
+    });
+
+    while let Some(message) = rx.recv().await {
+        println!("Sender says {}", message)
+    }
+}

--- a/src/channels/dispatch.rs
+++ b/src/channels/dispatch.rs
@@ -152,6 +152,7 @@ mod impl_futures {
 }
 
 impl<T> Sender<T> {
+    /// Creates a new Receiver that listens to this channel.
     pub fn subscribe(&self) -> Receiver<T> {
         Receiver {
             shared: self.shared.clone_receiver(),

--- a/src/channels/watch.rs
+++ b/src/channels/watch.rs
@@ -41,6 +41,13 @@ pub fn channel_with<T: Clone>(value: T) -> (Sender<T>, Receiver<T>) {
     (sender, receiver)
 }
 
+/// Constructs a pair of channel endpoints that store Option<T>
+///
+/// This is helpful if T does not implement Default, and you don't have an initial value.
+pub fn channel_with_option<T: Clone>() -> (Sender<Option<T>>, Receiver<Option<T>>) {
+    channel::<Option<T>>()
+}
+
 /// The sender half of a watch channel.  The stored value can be updated with the postage::Sink trait.
 pub struct Sender<T> {
     pub(in crate::channels::watch) shared: SenderShared<StateExtension<T>>,
@@ -83,6 +90,7 @@ impl<T> Sender<T> {
         }
     }
 
+    /// Creates a new Receiver that listens to this channel.
     pub fn subscribe(&mut self) -> Receiver<T> {
         Receiver {
             shared: self.shared.clone_receiver(),


### PR DESCRIPTION
- Add examples covering channels, combinators, and runtimes.
- Add watch::channel_with_option as a usability hint.  Often you need to store a value that has no initial value and does not implement Default.
- Update benchmarks